### PR TITLE
build.sbtの整理、scalafmt導入、あとgiter8のプラグイン消し忘れ修正

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,2 @@
+style = defaultWithAlign
+maxColumn = 120

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,20 @@
-name := """playtter"""
-organization := "higherkindpud"
+ThisBuild / scalaVersion := "2.13.2"
+ThisBuild / version      := "1.0-SNAPSHOT"
+ThisBuild / organization := "higherkindpud"
 
-version := "1.0-SNAPSHOT"
+lazy val commonSettings = Seq(
+  scalacOptions ++= "-deprecation" :: "-feature" :: "-Xlint" :: Nil,
+  scalacOptions in (Compile, console) ~= {_.filterNot(_ == "-Xlint")},
+  scalafmtOnCompile := true
+)
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
-
-scalaVersion := "2.13.2"
-
-libraryDependencies += guice
-libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test
-libraryDependencies += "com.dripower" %% "play-circe" % "2712.0"
-libraryDependencies += "redis.clients" % "jedis" % "3.3.0"
+lazy val root = (project in file("."))
+  .enablePlugins(PlayScala)
+  .settings(
+    name := "playtter",
+    commonSettings,
+    libraryDependencies += guice,
+    libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test,
+    libraryDependencies += "com.dripower" %% "play-circe" % "2712.0",
+    libraryDependencies += "redis.clients" % "jedis" % "3.3.0"
+  )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
-addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8-scaffold" % "0.11.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")


### PR DESCRIPTION
えっとまだsbt1.3.12をダウンロード中なので動くかわかりません

# build.sbt
* playframework/play-scala.seed.g8で作られるbuild.sbtは少し古い書き方
* この新しい書き方だとマルチプジェクトの設定が容易にできます
* commonSettingsにXlintとかを入れました
* `{_.filterNot(_ == "-Xlint")}` あたりの記述は、sbt consoleの時にunused importなどの警告が出ないようにするためです

# scalafmt
* コンパイル時にフォーマットがかかります

# giter8の消し忘れ
* はい